### PR TITLE
Restore Copyright

### DIFF
--- a/contracts/AppToken.sol
+++ b/contracts/AppToken.sol
@@ -1,5 +1,6 @@
 /*
   Copyright 2018 Menlo, Inc.
+  Copyright 2018 William Morriss
 
   Licensed under the Apache License, Version 2.0 (the “License”);
   you may not use this file except in compliance with the License.

--- a/contracts/Forum.sol
+++ b/contracts/Forum.sol
@@ -1,5 +1,6 @@
 /*
   Copyright 2018 Menlo, Inc.
+  Copyright 2018 William Morriss
 
   Licensed under the Apache License, Version 2.0 (the “License”);
   you may not use this file except in compliance with the License.

--- a/contracts/Lottery.sol
+++ b/contracts/Lottery.sol
@@ -1,5 +1,6 @@
 /*
   Copyright 2018 Menlo, Inc.
+  Copyright 2018 William Morriss
 
   Licensed under the Apache License, Version 2.0 (the “License”);
   you may not use this file except in compliance with the License.

--- a/contracts/Sponsored.sol
+++ b/contracts/Sponsored.sol
@@ -1,3 +1,18 @@
+/*
+  Copyright 2018 William Morriss
+
+  Licensed under the Apache License, Version 2.0 (the “License”);
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an “AS IS” BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
 pragma solidity^0.4.19;
 // like a less-liquid GasToken
 contract Sponsored {


### PR DESCRIPTION
#### Changes
This restores attribution to the solidity I wrote in compliance with the Apache license.
[Here](https://github.com/vulcanize/message_board_solidity) is the original repo.
Reviewers @daviddfm @gustin 